### PR TITLE
Fix: Update deprecated TwelveLabs SDK calls & upgraded to Marengo 3.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -328,7 +328,7 @@ class CreateTwelveLabsIndex(foo.Operator):
             model_options=so
         )]
 
-        index = client.index.create(
+        index = client.indexes.create(
             name=INDEX_NAME,
             models=models,
         )

--- a/__init__.py
+++ b/__init__.py
@@ -329,7 +329,7 @@ class CreateTwelveLabsIndex(foo.Operator):
         )]
 
         index = client.indexes.create(
-            name=INDEX_NAME,
+            index_name=INDEX_NAME,
             models=models,
         )
 

--- a/__init__.py
+++ b/__init__.py
@@ -215,8 +215,8 @@ class TwelveLabsSemanticSearch(foo.Operator):
             "Twelve Labs " + index_name, video_ids, ordered=True
         )
         print(f"Found {len(view1)} samples")
-        start = [entry.start for entry in search_results.data]
-        end = [entry.end for entry in search_results.data]
+        start = [entry.start for entry in search_results]
+        end = [entry.end for entry in search_results]
         if "results" in ctx.dataset.get_field_schema().keys():
             ctx.dataset.delete_sample_field("results")
 
@@ -406,13 +406,15 @@ class TwelveLabsIndexSearch(foo.Operator):
                 audio_flag = False
 
                 index_info = {}
-                indexes[0].models.root[0].options
+                # indexes[0].models.root[0].options
                 for index in indexes:
-                    if "visual" in index.models.root[0].options:
-                        vis_flag = True
-                    if "audio" in index.models.root[0].options:
-                        audio_flag = True
-                    index_info[index.name] = index.id
+                    for i, model in enumerate(index.models or [], 1):
+                        if "visual" in model.model_options:
+                            vis_flag = True
+                        if "audio" in model.model_options:
+                            audio_flag = True
+                    
+                    index_info[index.index_name] = index.id
 
                 choices = index_info.keys()
                 choices_compare = [
@@ -508,7 +510,7 @@ class TwelveLabsIndexSearch(foo.Operator):
 
         indexes = list(client.indexes.list())
         for index in indexes:
-            if index.name == index_name:
+            if index.index_name == index_name:
                 index_id = index.id
 
         prompt = ctx.params.get("prompt")
@@ -529,15 +531,15 @@ class TwelveLabsIndexSearch(foo.Operator):
                 index_id=index_id, query_text=prompt, search_options=so
             )
 
-        video_ids = [entry.video_id for entry in search_results.data]
+        video_ids = [entry.video_id for entry in search_results]
         print(f"Found {len(video_ids)} videos")
         samples = []
         view1 = target_view.select_by(
             "Twelve Labs " + index_name, video_ids, ordered=True
         )
         print(f"Found {len(view1)} samples")
-        start = [entry.start for entry in search_results.data]
-        end = [entry.end for entry in search_results.data]
+        start = [entry.start for entry in search_results]
+        end = [entry.end for entry in search_results]
         if "results" in ctx.dataset.get_field_schema().keys():
             ctx.dataset.delete_sample_field("results")
 

--- a/__init__.py
+++ b/__init__.py
@@ -167,7 +167,7 @@ class TwelveLabsSemanticSearch(foo.Operator):
         else:
             target_view = get_target_view(ctx, inputs)
             client = TwelveLabs(api_key=API_KEY)
-            indexes = client.indexes.list()
+            indexes = list(client.indexes.list())
 
             if not any(
                 field.startswith("Twelve Labs")
@@ -388,9 +388,10 @@ class TwelveLabsIndexSearch(foo.Operator):
         else:
             target_view = get_target_view(ctx, inputs)
             client = TwelveLabs(api_key=API_KEY)
-            indexes = client.indexes.list()
+            indexes = list(client.indexes.list())
 
             if indexes == []:
+                
                 inputs.view(
                     "No Index",
                     types.Warning(
@@ -398,6 +399,7 @@ class TwelveLabsIndexSearch(foo.Operator):
                         description="Please run `create semantic video index` first in order to semantic search on your dataset!",
                     ),
                 )
+
             else:
 
                 vis_flag = False
@@ -504,7 +506,7 @@ class TwelveLabsIndexSearch(foo.Operator):
 
         index_name = ctx.params.get("index_name")
 
-        indexes = client.indexes.list()
+        indexes = list(client.indexes.list())
         for index in indexes:
             if index.name == index_name:
                 index_id = index.id

--- a/__init__.py
+++ b/__init__.py
@@ -129,7 +129,7 @@ class CreateTwelveLabsEmbeddings(foo.Operator):
                     )
 
                     i += 1
-                    det.embedding = segment.embeddings_float
+                    det.embedding = segment.float_
                     dets.append(det)
 
                 # Edited sample name please verify that this works in Voxel51 platform integration.

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+from twelvelabs..indexes.types.indexes_create_request_models_item import IndexesCreateRequestModelsItem
 import fiftyone as fo
 import fiftyone.operators as foo
 from fiftyone.operators import types
@@ -8,7 +9,7 @@ import glob
 from pprint import pprint
 import os
 from twelvelabs import TwelveLabs
-
+from twelvelabs.embed import TasksStatusResponse
 
 class CreateTwelveLabsEmbeddings(foo.Operator):
     @property
@@ -99,22 +100,24 @@ class CreateTwelveLabsEmbeddings(foo.Operator):
                 file_name = sample.filepath.split("/")[-1]
                 file_path = sample.filepath
 
-                task = client.embed.task.create(
-                    model_name="Marengo-retrieval-2.7",
+                task = client.embed.tasks.create(
+                    model_name="marengo3.0",
                     video_file=file_path,
                 )
 
-                def on_task_update(task):
+                def on_task_update(task: TasksStatusResponse):
                     print(f"  Status={task.status}")
 
-                task.wait_for_done(sleep_interval=5, callback=on_task_update)
+                status = client.embed.tasks.wait_for_done(task.id, callback=on_task_update, sleep_interval=1)
 
-                if task.status != "ready":
-                    raise RuntimeError(f"Indexing failed with status {task.status}")
-
-                retrieved_task = task.retrieve(
-                    embedding_option=["visual-text", "audio"]
+                retrieved_task = client.embed.tasks.retrieve(
+                    task_id=task.id,
+                    embedding_option=["visual", "audio"]
                 )
+
+                if not retrieved_task.video_embedding or not retrieved_task.video_embedding.segments:
+                    raise ValueError("No embeddings found for video: " + file_name)
+
                 i = 0
                 dets = []
                 for segment in retrieved_task.video_embedding.segments:
@@ -128,7 +131,8 @@ class CreateTwelveLabsEmbeddings(foo.Operator):
                     det.embedding = segment.embeddings_float
                     dets.append(det)
 
-                sample["Twelve Labs Marengo-retrieval-27"] = fo.TemporalDetections(
+                # Edited sample name please verify that this works in Voxel51 platform integration.
+                sample["Twelve Labs Marengo-3.0"] = fo.TemporalDetections(
                     detections=dets
                 )
                 sample.save()
@@ -162,7 +166,7 @@ class TwelveLabsSemanticSearch(foo.Operator):
         else:
             target_view = get_target_view(ctx, inputs)
             client = TwelveLabs(api_key=API_KEY)
-            indexes = client.index.list()
+            indexes = client.indexes.list()
 
             if not any(
                 field.startswith("Twelve Labs")
@@ -200,7 +204,7 @@ class TwelveLabsSemanticSearch(foo.Operator):
         prompt = ctx.params.get("prompt")
 
         res = client.embed.create(
-            model_name="Marengo-retrieval-2.7",
+            model_name="marengo3.0",
             text=prompt,
         )
 
@@ -319,7 +323,10 @@ class CreateTwelveLabsIndex(foo.Operator):
         if ctx.params.get("audio"):
             so.append("audio")
 
-        models = [{"name": "marengo2.7", "options": so}]
+        models = [IndexesCreateRequestModelsItem(
+            model_name="marengo3.0",
+            model_options=so
+        )]
 
         index = client.index.create(
             name=INDEX_NAME,
@@ -336,14 +343,14 @@ class CreateTwelveLabsIndex(foo.Operator):
                 file_name = sample.filepath.split("/")[-1]
                 file_path = sample.filepath
 
-                task = client.task.create(index_id=index_id, file=file_path)
+                task = client.tasks.create(index_id=index_id, video_file=file_path)
 
                 def on_task_update(task):
                     print(f"  Status={task.status}")
 
-                task.wait_for_done(sleep_interval=5, callback=on_task_update)
+                status_task = client.tasks.wait_for_done(task_id=task.id, callback=on_task_update)
 
-                if task.status != "ready":
+                if status_task.status != "ready":
                     raise RuntimeError(f"Indexing failed with status {task.status}")
 
                 video_id = task.video_id
@@ -380,7 +387,7 @@ class TwelveLabsIndexSearch(foo.Operator):
         else:
             target_view = get_target_view(ctx, inputs)
             client = TwelveLabs(api_key=API_KEY)
-            indexes = client.index.list()
+            indexes = client.indexes.list()
 
             if indexes == []:
                 inputs.view(
@@ -496,7 +503,7 @@ class TwelveLabsIndexSearch(foo.Operator):
 
         index_name = ctx.params.get("index_name")
 
-        indexes = client.index.list()
+        indexes = client.indexes.list()
         for index in indexes:
             if index.name == index_name:
                 index_id = index.id
@@ -512,11 +519,11 @@ class TwelveLabsIndexSearch(foo.Operator):
 
         if len(so) >= 2:
             search_results = client.search.query(
-                index_id=index_id, query_text=prompt, options=so, operator="and"
+                index_id=index_id, query_text=prompt, search_options=so, operator="and"
             )
         else:
             search_results = client.search.query(
-                index_id=index_id, query_text=prompt, options=so
+                index_id=index_id, query_text=prompt, search_options=so
             )
 
         video_ids = [entry.video_id for entry in search_results.data]

--- a/__init__.py
+++ b/__init__.py
@@ -132,8 +132,7 @@ class CreateTwelveLabsEmbeddings(foo.Operator):
                     det.embedding = segment.float_
                     dets.append(det)
 
-                # Edited sample name please verify that this works in Voxel51 platform integration.
-                sample["Twelve Labs Marengo-3.0"] = fo.TemporalDetections(
+                sample["Twelve Labs Marengo-retrieval-27"] = fo.TemporalDetections(
                     detections=dets
                 )
                 sample.save()

--- a/__init__.py
+++ b/__init__.py
@@ -99,11 +99,12 @@ class CreateTwelveLabsEmbeddings(foo.Operator):
             else:
                 file_name = sample.filepath.split("/")[-1]
                 file_path = sample.filepath
-
-                task = client.embed.tasks.create(
-                    model_name="marengo3.0",
-                    video_file=file_path,
-                )
+                
+                with open(file_path, "rb") as f:
+                    task = client.embed.tasks.create(
+                        model_name="marengo3.0",
+                        video_file=f,
+                    )
 
                 def on_task_update(task: TasksStatusResponse):
                     print(f"  Status={task.status}")
@@ -208,7 +209,6 @@ class TwelveLabsSemanticSearch(foo.Operator):
             text=prompt,
         )
 
-        
         print(f"Found {len(video_ids)} videos")
         samples = []
         view1 = target_view.select_by(
@@ -343,7 +343,8 @@ class CreateTwelveLabsIndex(foo.Operator):
                 file_name = sample.filepath.split("/")[-1]
                 file_path = sample.filepath
 
-                task = client.tasks.create(index_id=index_id, video_file=file_path)
+                with open(file_path, "rb") as f:
+                    task = client.tasks.create(index_id=index_id, video_file=f)
 
                 def on_task_update(task):
                     print(f"  Status={task.status}")

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-from twelvelabs..indexes.types.indexes_create_request_models_item import IndexesCreateRequestModelsItem
 import fiftyone as fo
 import fiftyone.operators as foo
 from fiftyone.operators import types
@@ -10,6 +9,7 @@ from pprint import pprint
 import os
 from twelvelabs import TwelveLabs
 from twelvelabs.embed import TasksStatusResponse
+from twelvelabs.indexes import IndexesCreateRequestModelsItem
 
 class CreateTwelveLabsEmbeddings(foo.Operator):
     @property

--- a/fiftyone.yml
+++ b/fiftyone.yml
@@ -1,9 +1,9 @@
-name: "@nathanchess/semantic_video_search"
-description: Semantic Video Search 3.0
+name: "@danielgural/semantic_video_search"
+description: Semantic Video Search
 version: 1.0.0
 fiftyone:
   version: "*"
-url: https://github.com/nathanchess/semantic_video_search/tree/marengo-update
+url: https://github.com/danielgural/semantic_video_search/blob/main/README.md
 license: Apache 2.0
 operators:
   - twelve_labs_index_search

--- a/fiftyone.yml
+++ b/fiftyone.yml
@@ -1,9 +1,9 @@
-name: "@danielgural/semantic_video_search"
-description: Semantic Video Search
+name: "@nathanchess/semantic_video_search"
+description: Semantic Video Search 3.0
 version: 1.0.0
 fiftyone:
   version: "*"
-url: https://github.com/danielgural/semantic_video_search/blob/main/README.md
+url: https://github.com/nathanchess/semantic_video_search/tree/marengo-update
 license: Apache 2.0
 operators:
   - twelve_labs_index_search


### PR DESCRIPTION
This PR updates the semantic_video_search FiftyOne plugin to be compatible with the latest Twelve Labs SDK and Marengo 3.0.

Changes include:
- Fixed file upload to Twelve Labs API: Changed video_file parameter to pass an opened file object instead of a string path, resolving video_file_broken errors.
- Fixed index attribute access: Updated index.name to index.index_name to match the current SDK schema.
- Fixed model options access: Updated index.models.root[0].options to iterate over index.models and access model.model_options.
- Fixed embedding attribute: Changed segment.embeddings_float to segment.float_.
- Fixed search results iteration: Removed .data accessor from search_results as the response is directly iterable.

Testing:
- Verified plugin loads correctly in FiftyOne application through manually loading quickstart-video zoo dataset.
- Tested index creation and video indexing workflows.